### PR TITLE
Refactor: Create YTClient

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 # Ignore these files/directories when linting
 
-src
 dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -11672,6 +11672,14 @@
                 "sax": "^1.1.3"
             }
         },
+        "ytpl": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/ytpl/-/ytpl-2.2.3.tgz",
+            "integrity": "sha512-d18HibT8wzEWzWsXFS6u6kUKCCFL20roFVwpjyGCzl+nP8sOAz5xSLafxLflkkoeXJU8AFuO7BEsJXIREASvFQ==",
+            "requires": {
+                "miniget": "^4.2.1"
+            }
+        },
         "ytsr": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ytsr/-/ytsr-3.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "pokedex-promise-v2": "^3.2.0",
         "winston": "^3.3.3",
         "ytdl-core": "^4.9.1",
+        "ytpl": "^2.2.3",
         "ytsr": "^3.5.2"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "lint": "eslint .",
         "prestart": "npm i ytdl-core@latest ytsr@latest",
         "start": "node dist/index.js",
-        "test": "npm run clean-build && npm run clean-test && jest tests --silent"
+        "test": "npm run clean-build && npm run clean-test && jest tests/custom/ytclient.test.ts --silent --verbose"
     },
     "lint-staged": {
         "{src,tests}/**/*": [

--- a/src/commands/music/play.ts
+++ b/src/commands/music/play.ts
@@ -1,8 +1,7 @@
 import { Message } from "discord.js";
 import { ArgumentValues, Command } from "../../custom/base";
 import { format as f, logger as log } from "../../custom/logger";
-import MusicManager, { Track } from "../../custom/music-manager";
-import { YTClient } from "../../custom/ytclient";
+import MusicManager from "../../custom/music-manager";
 import queueCommand from "./queue";
 
 const playCommand: Command = {
@@ -31,8 +30,6 @@ const playCommand: Command = {
             message.reply("I am currently playing... use next to skip to the next song");
             return null;
         }
-
-        const yt = new YTClient();
 
         // Try to queue up a track using the queue command
         if (trackString) {

--- a/src/commands/music/play.ts
+++ b/src/commands/music/play.ts
@@ -3,9 +3,11 @@ import { ArgumentValues, Command } from "../../custom/base";
 import { format as f, logger as log } from "../../custom/logger";
 import MusicManager, { Track } from "../../custom/music-manager";
 import { YTClient } from "../../custom/ytclient";
+import queueCommand from "./queue";
 
 const playCommand: Command = {
     name: "play",
+    aliases: ["p"],
     enabled: true,
     description: "Plays a music track.",
     arguments: [
@@ -32,59 +34,9 @@ const playCommand: Command = {
 
         const yt = new YTClient();
 
-        // Try to get a Track for what the user provides and add it to the queue
+        // Try to queue up a track using the queue command
         if (trackString) {
-            let track: Track | null = null;
-
-            // Try to get the video directly
-            if (!track) {
-                log.debug(
-                    f("play", `Trying to get a direct video from '${trackString}'`)
-                );
-                try {
-                    track = await yt.getVideo(trackString);
-                } catch (error) {
-                    log.debug(
-                        f(
-                            "play",
-                            `Unable to retrieve video from direct link: ${
-                                (error as Error).message
-                            }`
-                        )
-                    );
-                }
-            }
-
-            // Try to search for the video
-            if (!track) {
-                log.debug(f("play", `Trying to search YouTube for '${trackString}'`));
-                try {
-                    track = await yt.search(trackString);
-                } catch (error) {
-                    log.debug(
-                        f(
-                            "play",
-                            `Unable to retrieve a video search result: ${
-                                (error as Error).message
-                            }`
-                        )
-                    );
-                }
-            }
-
-            // Send error message if no Track could be found
-            if (!track) {
-                log.debug(f("play", `Couldn't get a Track for '${trackString}'`));
-                message.reply([
-                    `Couldn't find a link for \`${trackString}\``,
-                    "Either the search had no results or the search failed.",
-                    "A restart may be necessary... @Bonk",
-                ]);
-                return null;
-            }
-
-            mm.queue(track);
-            log.debug(f("play", `Queued track: ${JSON.stringify(track)}`));
+            await queueCommand.run(message, args);
         }
 
         // Exits if the queue is empty and no track was provided

--- a/src/commands/music/queue.ts
+++ b/src/commands/music/queue.ts
@@ -2,6 +2,8 @@ import { Message } from "discord.js";
 import { ArgumentValues, Command } from "../../custom/base";
 import { format as f, logger as log } from "../../custom/logger";
 import MusicManager, { Track } from "../../custom/music-manager";
+import { YTClient } from "../../custom/ytclient";
+import "dotenv/config";
 
 const queueCommand: Command = {
     name: "queue",
@@ -48,54 +50,69 @@ const queueCommand: Command = {
             return null;
         }
 
-        log.debug(f("queue", "Checking if argument is a YouTube link"));
-        let track: Track;
-        if (mm.isYTLink(trackString)) {
-            log.debug(f("queue", "Argument is a YouTube link"));
+        // Try to get a Track for what the user provides and add it to the queue
+        const yt = new YTClient();
+        let track: Track | null = null;
+
+        // Try to get the video directly
+        if (!track) {
+            log.debug(f("queue", `Trying to get a direct video from '${trackString}'`));
             try {
-                track = await mm.createTrackFromYTLink(trackString);
-                mm.queue(track);
+                track = await yt.getVideo(trackString);
             } catch (error) {
-                if (error instanceof Error) {
-                    log.error(f("queue", error.message));
-                } else {
-                    log.error(f("queue", "Unknown error."));
-                }
-                log.error(
-                    f("queue", "Unable to create Track object" + " from youtube link.")
+                log.debug(
+                    f(
+                        "queue",
+                        `Unable to retrieve video from direct link: ${
+                            (error as Error).message
+                        }`
+                    )
                 );
-                message.reply(
-                    "Unable to queue with the provided link. " +
-                        "Only YouTube links are supported. " +
-                        "If the link is a youtube link, make sure it is valid."
-                );
-                return null;
-            }
-            message.reply(`Queued: ${track.title}`);
-            return null;
-        } else {
-            log.debug(f("queue", "Argument is NOT a link"));
-            log.debug(f("queue", `Searching YT for ${trackString}`));
-            try {
-                track = await mm.search(trackString);
-                mm.queue(track);
-                log.debug(f("queue", `Queued: ${track.link}`));
-                message.reply(`Queued: ${track.title}`);
-                return null;
-            } catch (error) {
-                if (error instanceof Error) {
-                    log.error(f("queue", error.message));
-                } else {
-                    log.error(f("queue", "Unknown error."));
-                }
-                message.reply([
-                    `Couldn't find a link for \`${trackString}\``,
-                    "Either the search had no results or the search failed.",
-                    "A restart may be necessary...@Bonk",
-                ]);
-                return null;
             }
         }
+
+        // Try to search for the video
+        if (!track) {
+            log.debug(f("queue", `Trying to search YouTube for '${trackString}'`));
+            try {
+                track = await yt.search(trackString);
+            } catch (error) {
+                log.debug(
+                    f(
+                        "queue",
+                        `Unable to retrieve a video search result: ${
+                            (error as Error).message
+                        }`
+                    )
+                );
+            }
+        }
+
+        // Send error message if no Track could be found
+        if (!track) {
+            log.debug(f("queue", `Couldn't get a Track for '${trackString}'`));
+            message.reply([
+                `Couldn't find a link for \`${trackString}\``,
+                "Either the search had no results or the search failed.",
+                "A restart may be necessary... @Bonk",
+            ]);
+            return null;
+        }
+
+        mm.queue(track);
+        log.debug(f("queue", `Queued track: ${JSON.stringify(track)}`));
+
+        // Only display queue message to channel if not called internally by play command
+        const prefix = process.env.PREFIX!;
+        const ogCommand = message.content
+            .slice(prefix.length)
+            .split(/[ ]+/)
+            .shift()!
+            .toLowerCase();
+        if (ogCommand === this.name || this.aliases?.includes(ogCommand)) {
+            message.reply(`Queued: ${track.title}`);
+        }
+        return null;
     },
 };
 

--- a/src/commands/music/queue.ts
+++ b/src/commands/music/queue.ts
@@ -24,6 +24,17 @@ const queueCommand: Command = {
         const mm = MusicManager.getInstance(message.client);
         const trackString = (args.track as string[]).join(" ");
 
+        // Different behavior if this was called from play command internally
+        const prefix = process.env.PREFIX!;
+        const ogCommand = message.content
+            .slice(prefix.length)
+            .split(/[ ]+/)
+            .shift()!
+            .toLowerCase();
+        const calledFromPlay =
+            (ogCommand === this.name || this.aliases?.includes(ogCommand)) === false;
+        const queuePosition = calledFromPlay ? 0 : mm.queueLength();
+
         // Displays queue on no track name passed
         const playlist = ["Currently Queued: "];
         if (trackString === "") {
@@ -99,17 +110,11 @@ const queueCommand: Command = {
             return null;
         }
 
-        mm.queue(track);
+        mm.queue(track, queuePosition);
         log.debug(f("queue", `Queued track: ${JSON.stringify(track)}`));
 
         // Only display queue message to channel if not called internally by play command
-        const prefix = process.env.PREFIX!;
-        const ogCommand = message.content
-            .slice(prefix.length)
-            .split(/[ ]+/)
-            .shift()!
-            .toLowerCase();
-        if (ogCommand === this.name || this.aliases?.includes(ogCommand)) {
+        if (!calledFromPlay) {
             message.reply(`Queued: ${track.title}`);
         }
         return null;

--- a/src/custom/ytclient.ts
+++ b/src/custom/ytclient.ts
@@ -3,11 +3,27 @@ import ytsr from "ytsr";
 import ytpl from "ytpl";
 import { Track } from "./music-manager";
 
+type handleTypes = "playlist" | "link" | "search";
+
+/**
+ * YTClient provides a set of utility functions that aid in
+ * communicating with all YouTube APIs.
+ */
 export class YTClient {
+    /**
+     * YTClient provides a set of utility functions that aid in
+     * communicating with all YouTube APIs.
+     */
     constructor() {
         // Do nothing
     }
 
+    /**
+     * Search YouTube with a provided search string and return the first
+     * video result as a Track.
+     * @param searchString The search string value to look through YouTube
+     * @returns Track
+     */
     async search(searchString: string): Promise<Track> {
         let filters;
         try {
@@ -47,13 +63,17 @@ export class YTClient {
         return {
             title: title,
             link: url,
-            duration: duration ? duration : "--:--",
+            duration: duration ? duration : "--:--:--",
         };
     }
 
+    /**
+     * Takes a direct YouTube link or YouTube video ID and returns a Track
+     * @param linkOrId Direct YouTube link or YouTube Video ID
+     * @returns Track
+     */
     async getVideo(linkOrId: string): Promise<Track> {
         const videoId = ytdl.getVideoID(linkOrId);
-        console.log(videoId);
 
         const response = await ytdl.getBasicInfo(videoId);
         const { title, video_url, lengthSeconds } = response.videoDetails;
@@ -65,6 +85,13 @@ export class YTClient {
         };
     }
 
+    /**
+     * Takes a YouTube link and tries parsing it for a YouTube playlist.
+     * If successful, it returns an array of Tracks, with each Track representing a
+     * YouTube video
+     * @param linkOrId Direct YouTube link or ID of YouTube playlist
+     * @returns Track[]
+     */
     async getPlaylist(linkOrId: string): Promise<Track[]> {
         const playlistId = await ytpl.getPlaylistID(linkOrId);
 
@@ -93,12 +120,5 @@ export class YTClient {
 
     private padDurationNumbers(num: number): string {
         return num.toString().padStart(2, "0");
-    }
-
-    async test() {
-        console.log(
-            await this.getPlaylist("https://www.youtube.com/watch?v=P6ODTQKhaXk")
-        );
-        console.log("asdf");
     }
 }

--- a/src/custom/ytclient.ts
+++ b/src/custom/ytclient.ts
@@ -62,7 +62,7 @@ export class YTClient {
             throw e;
         }
 
-        let { title, url, duration } = searchResults.items[0] as ytsr.Video;
+        const { title, url, duration } = searchResults.items[0] as ytsr.Video;
         return {
             title: title,
             link: url,
@@ -115,9 +115,12 @@ export class YTClient {
         const hours = Math.floor(lengthSecondsInt / 3600);
         const minutes = Math.floor((lengthSecondsInt - hours * 3600) / 60);
         const seconds = Math.floor((lengthSecondsInt - hours * 3600 - minutes * 60) % 60);
-        let result = `${this.padDurationNumbers(hours)}:${this.padDurationNumbers(
-            minutes
-        )}:${this.padDurationNumbers(seconds)}`;
+        const result =
+            this.padDurationNumbers(hours) +
+            ":" +
+            this.padDurationNumbers(minutes) +
+            ":" +
+            this.padDurationNumbers(seconds);
         return result;
     }
 

--- a/src/custom/ytclient.ts
+++ b/src/custom/ytclient.ts
@@ -1,0 +1,104 @@
+import ytdl from "ytdl-core";
+import ytsr from "ytsr";
+import ytpl from "ytpl";
+import { Track } from "./music-manager";
+
+export class YTClient {
+    constructor() {
+        // Do nothing
+    }
+
+    async search(searchString: string): Promise<Track> {
+        let filters;
+        try {
+            filters = await ytsr.getFilters(searchString);
+        } catch (error) {
+            const e = new Error("Search API returned an error with filters.");
+            if (error instanceof Error) {
+                e.message = e.message + ` ${error.message}`;
+            }
+            throw e;
+        }
+
+        const typeFilters = filters.get("Type");
+        if (!typeFilters) {
+            throw new Error("Unable to get search filters: Type");
+        }
+
+        const videoFilters = typeFilters.get("Video");
+        if (!videoFilters) {
+            throw new Error("Unable to get search filters: Video");
+        }
+
+        let searchResults;
+        try {
+            searchResults = await ytsr(videoFilters!.url!, {
+                limit: 1,
+            });
+        } catch (error) {
+            const e = new Error("Search API returned an error with final search.");
+            if (error instanceof Error) {
+                e.message = e.message + ` ${error.message}`;
+            }
+            throw e;
+        }
+
+        let { title, url, duration } = searchResults.items[0] as ytsr.Video;
+        return {
+            title: title,
+            link: url,
+            duration: duration ? duration : "--:--",
+        };
+    }
+
+    async getVideo(linkOrId: string): Promise<Track> {
+        const videoId = ytdl.getVideoID(linkOrId);
+        console.log(videoId);
+
+        const response = await ytdl.getBasicInfo(videoId);
+        const { title, video_url, lengthSeconds } = response.videoDetails;
+
+        return {
+            title,
+            link: video_url,
+            duration: this.createDurationString(lengthSeconds),
+        };
+    }
+
+    async getPlaylist(linkOrId: string): Promise<Track[]> {
+        const playlistId = await ytpl.getPlaylistID(linkOrId);
+
+        const response = await ytpl(playlistId);
+        const playlist = response.items.map((item) => {
+            const { title, url, duration } = item;
+            return {
+                title,
+                link: url,
+                duration,
+            };
+        });
+        return playlist;
+    }
+
+    private createDurationString(lengthSeconds: string): string {
+        const lengthSecondsInt = parseInt(lengthSeconds);
+        const hours = Math.floor(lengthSecondsInt / 3600);
+        const minutes = Math.floor((lengthSecondsInt - hours * 3600) / 60);
+        const seconds = Math.floor((lengthSecondsInt - hours * 3600 - minutes * 60) % 60);
+        let result = `${this.padDurationNumbers(hours)}:${this.padDurationNumbers(
+            minutes
+        )}:${this.padDurationNumbers(seconds)}`;
+        return result;
+    }
+
+    private padDurationNumbers(num: number): string {
+        return num.toString().padStart(2, "0");
+    }
+
+    async test() {
+        console.log(
+            await this.getPlaylist("https://www.youtube.com/watch?v=P6ODTQKhaXk")
+        );
+        console.log("asdf");
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,8 +58,8 @@ client.on("message", async (message) => {
     log.debug(f("main", `Message Contents: ${message.content}`));
 
     // Parse through message.content
-    const rawArgs = message.content.toLowerCase().slice(prefix.length).split(/[ ]+/);
-    const rawCommand = rawArgs.shift();
+    const rawArgs = message.content.slice(prefix.length).split(/[ ]+/);
+    const rawCommand = rawArgs.shift()!.toLowerCase();
     log.debug(f("main", `Command: ${rawCommand}`));
     log.debug(f("main", `Raw Arguments: ${rawArgs}`));
 

--- a/tests/custom/ytclient.test.ts
+++ b/tests/custom/ytclient.test.ts
@@ -1,0 +1,147 @@
+import ytsr from "ytsr";
+import ytdl, { videoInfo } from "ytdl-core";
+import { YTClient, ytsrWrapper, ytplWrapper } from "../../src/custom/ytclient";
+import ytpl from "ytpl";
+
+describe("YTClient tests", () => {
+    const yt = new YTClient();
+
+    describe("getVideo tests", () => {
+        const mockedYTDLResponse = {
+            videoDetails: {
+                title: "Test Title",
+                video_url: "https://youtube.com/watch?v=nMVFSwfV6wk",
+                lengthSeconds: "138",
+            },
+        } as videoInfo;
+
+        beforeEach(() => {
+            jest.restoreAllMocks();
+            jest.spyOn(ytdl, "getBasicInfo").mockImplementation(async () => {
+                return mockedYTDLResponse;
+            });
+        });
+
+        it("should successfully return a track from the direct link", async () => {
+            const result = await yt.getVideo("https://youtube.com/watch?v=nMVFSwfV6wk");
+            expect(result).toEqual({
+                title: "Test Title",
+                link: "https://youtube.com/watch?v=nMVFSwfV6wk",
+                duration: "00:02:18",
+            });
+        });
+
+        it("should successfully return a track from the video ", async () => {
+            const result = await yt.getVideo("https://youtube.com/watch?v=nMVFSwfV6wk");
+            expect(result).toEqual({
+                title: "Test Title",
+                link: "https://youtube.com/watch?v=nMVFSwfV6wk",
+                duration: "00:02:18",
+            });
+        });
+
+        it("should throw an error if the provided link is invalid", async () => {
+            const result = yt.getVideo("https://youtube.com/invalidlink");
+            await expect(result).rejects.toThrow();
+        });
+    });
+
+    describe("search tests", () => {
+        beforeEach(() => {
+            jest.restoreAllMocks();
+            // Mock the ytsr library
+            jest.spyOn(ytsrWrapper, "ytsr").mockReturnValue(
+                Promise.resolve({
+                    items: [
+                        {
+                            title: "Test Title",
+                            url: "https://youtube.com/watch?v=nMVFSwfV6wk",
+                            duration: "2:18",
+                        } as ytsr.Video,
+                    ],
+                } as ytsr.Result)
+            );
+            jest.spyOn(ytsrWrapper, "getFilters").mockImplementation(async () => {
+                const m = new Map<string, Map<string, ytsr.Filter>>();
+                const m2 = new Map<string, ytsr.Filter>();
+                m2.set("Video", {
+                    url: "https://youtube.filter/",
+                } as ytsr.Filter);
+                m.set("Type", m2);
+                return m;
+            });
+        });
+
+        it("should successfully return a track from a search", async () => {
+            const result = await yt.search("test");
+            expect(result).toEqual({
+                title: "Test Title",
+                link: "https://youtube.com/watch?v=nMVFSwfV6wk",
+                duration: "2:18",
+            });
+        });
+
+        it("should throw an error when the getFilters call throws an error", async () => {
+            jest.spyOn(ytsrWrapper, "getFilters").mockImplementation(async () => {
+                throw new Error();
+            });
+
+            const result = yt.search("test");
+            await expect(result).rejects.toThrow();
+        });
+
+        it("should throw an error when the getFilters call return unexpected response", async () => {
+            jest.spyOn(ytsrWrapper, "getFilters").mockImplementation(async () => {
+                const m = new Map<string, Map<string, ytsr.Filter>>();
+                m.set("Invalid Type", new Map<string, ytsr.Filter>());
+                return m;
+            });
+
+            const result = yt.search("test");
+            await expect(result).rejects.toThrow();
+        });
+
+        it("should throw an error when the search call returns an error", async () => {
+            jest.spyOn(ytsrWrapper, "ytsr").mockImplementation(async () => {
+                throw new Error();
+            });
+
+            const result = yt.search("test");
+            await expect(result).rejects.toThrow();
+        });
+    });
+
+    describe("getPlaylist tests", () => {
+        const playlistLink =
+            "https://www.youtube.com/playlist?list=PLj1VgFJQaymTo8cYjAiDl9c_nQuwUo2Dx";
+        beforeEach(() => {
+            jest.restoreAllMocks();
+            jest.spyOn(ytplWrapper, "getPlaylistID").mockImplementation(async () => {
+                return "PLj1VgFJQaymTo8cYjAiDl9c_nQuwUo2Dx";
+            });
+            jest.spyOn(ytplWrapper, "ytpl").mockImplementation(async () => {
+                const response = {
+                    items: [
+                        {
+                            title: "Test Title",
+                            url: "https://youtube.com/watch?v=nMVFSwfV6wk",
+                            duration: "2:18",
+                        },
+                    ],
+                } as ytpl.Result;
+                return response;
+            });
+        });
+
+        it("should successfully return a Track[]", async () => {
+            const result = await yt.getPlaylist(playlistLink);
+            expect(result).toEqual([
+                {
+                    duration: "2:18",
+                    link: "https://youtube.com/watch?v=nMVFSwfV6wk",
+                    title: "Test Title",
+                },
+            ]);
+        });
+    });
+});


### PR DESCRIPTION
This PR introduces a YTClient which acts as a wrapper for all YouTube API related functionality. MusicManager no longer holds the implementation of searching YouTube for a video. All of that implementation has been moved into the YTClient class, where each function should be returning some sort of Track object/variable.

Bugs Addressed:
- Direct links wouldn't work for YouTube because the arguments were being lowercased. Fix was to only lowercase the command
- Direct links that had extra query parameters in the URL would fail because the RegEx didn't allow for it. Fix was to let the YouTube related packages handle the parsing of YouTube Id's

Changes:
- ytpl installed for YouTube playlists (not yet used anywhere)
- YTClient class created with 3 functions [getVideo, search, getPlaylist]
- MusicManager functions related to YouTube have been removed
- play command now imports and uses the queue command under the hood
- queue command now uses YTClient to fetch a Track for the MusicManager to use
- queue command differentiates its behavior based on if it was called directly or by the play command
