### PR TITLE
Refactor: Base.ts Cleanup

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -27,3 +27,6 @@ jobs:
 
             - name: Check for linting errors
               run: npm run lint
+
+            - name: Run Unit Tests
+              run: npm test

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "lint": "eslint .",
         "prestart": "npm i ytdl-core@latest ytsr@latest",
         "start": "node dist/index.js",
-        "test": "npm run clean-build && npm run clean-test && jest tests/custom/ytclient.test.ts --silent --verbose"
+        "test": "npm run clean-build && npm run clean-test && jest tests/custom/ytclient.test.ts tests/custom/validators.test.ts tests/custom/base.test.ts --silent --verbose"
     },
     "lint-staged": {
         "{src,tests}/**/*": [

--- a/src/custom/base.ts
+++ b/src/custom/base.ts
@@ -35,7 +35,6 @@ export interface Argument {
  * @property all other properties can be referenced by this.key
  * @example args.key1
  * @example args.full
- * @exampl
  */
 export type ArgumentValues = {
     /** Key/Value pair of the argument */
@@ -57,6 +56,7 @@ export type ArgumentValues = {
  * @param rawArgs The raw string containing all of the arguments to be parsed
  * @param argsInfo An array of the configuration argument information for each argument
  * @param guild The guild where the command was triggered from (used for fetching guildMembers for user arguments)
+ * @throws ArgumentUsageError | ArgumentDefinitionError | ArgumentCustomValidationError
  * @returns An ArgumentValues structure containing key value pairs for each argument definition.
  */
 export async function parseArgs(

--- a/src/custom/base.ts
+++ b/src/custom/base.ts
@@ -140,12 +140,6 @@ export async function parseArgs(
                     parsedValue.push(await validateUser(val, guild));
                 }
                 break;
-            default:
-                // Shouldn't ever enter here
-                throw new Error(
-                    "Entered default switch case. You somehow entered an invalid argument type: " +
-                        arg.type
-                );
         }
 
         // Uses custom validator if one is passed

--- a/src/custom/base.ts
+++ b/src/custom/base.ts
@@ -4,6 +4,9 @@ import { ArgumentDefinitionError } from "../errors/ArgumentDefinitionError";
 import { ArgumentUsageError } from "../errors/ArgumentUsageError";
 import { validateNumber, validateBoolean, validateUser } from "./validators";
 
+/**
+ * Defines a Command argument and how to configure one
+ */
 export interface Argument {
     /** The key to reference this argument */
     key: string;
@@ -19,7 +22,8 @@ export interface Argument {
      * Expects the parameter type to be the same as the argument.type*/
     validator?: (value: any) => boolean;
     /** Whether or not this argument takes infinite number of values.
-     * Will return an array of the defined type.
+     * Will return an array of the defined type. Can only be defined
+     * for the last argument if there are multiple arguments defined.
      */
     infinite?: boolean;
 }
@@ -28,7 +32,6 @@ export interface Argument {
  * @property full - The full string of all the argument values passed in
  * @property remaining - If there are more args passed in than defined,
  * the remaining will be populated here
- * @property fullarr - The full list of arguments will be populated here as a string[]
  * @property all other properties can be referenced by this.key
  * @example args.key1
  * @example args.full
@@ -90,7 +93,7 @@ export async function parseArgs(
         full: argValues.join(" "),
     };
 
-    while (argsInfo.length) {
+    while (argsInfo.length > 0) {
         const arg = argsInfo.shift()!;
         let value = argValues.shift()!;
 
@@ -120,7 +123,7 @@ export async function parseArgs(
         }
 
         // Validate and parse the value
-        let parsedValue: any[] | string;
+        let parsedValue: any[];
         switch (arg.type) {
             case "string":
                 parsedValue = value.split(" ");
@@ -132,11 +135,9 @@ export async function parseArgs(
                 parsedValue = value.split(" ").map((val) => validateBoolean(val));
                 break;
             case "user":
-                parsedValue = [];
+                parsedValue = [] as (GuildMember | undefined)[];
                 for (const val of value.split(" ")) {
-                    (parsedValue as (GuildMember | undefined)[]).push(
-                        await validateUser(val, guild)
-                    );
+                    parsedValue.push(await validateUser(val, guild));
                 }
                 break;
             default:
@@ -159,24 +160,13 @@ export async function parseArgs(
             }
         }
 
-        // Parse values as an array if argument expected infinite
         // Throw usage error if validators returned undefined
-        if (arg.infinite !== true) {
-            if (parsedValue[0] !== undefined) {
-                result[arg.key] = parsedValue[0];
-            } else {
-                throw new ArgumentUsageError(arg, value);
-            }
-        } else {
-            result[arg.key] = [];
-            for (const val of parsedValue) {
-                if (val !== undefined) {
-                    (result[arg.key] as any[]).push(val);
-                } else {
-                    throw new ArgumentUsageError(arg, value);
-                }
-            }
+        if (parsedValue.includes(undefined)) {
+            throw new ArgumentUsageError(arg, value);
         }
+
+        // Parse values as an array if infinite flag is true
+        result[arg.key] = arg.infinite ? parsedValue : parsedValue[0];
     }
 
     if (argValues.length > 0) {
@@ -186,12 +176,17 @@ export async function parseArgs(
     return result;
 }
 
+/**
+ * Defines a Command and how to configure.
+ */
 export interface Command {
     /** The default name of the command */
     name: string;
     /** A short description of the command */
     description: string;
-    /** The configuration information about the arguments of the command */
+    /** The configuration information about the arguments of the command.
+     * See the Argument interface for more detailed information
+     */
     arguments: Argument[];
     /**
      * The function to run when the command is triggered

--- a/tests/custom/base.test.ts
+++ b/tests/custom/base.test.ts
@@ -18,7 +18,7 @@ describe("Testing base.ts/parseArgs()", () => {
         jest.restoreAllMocks();
     });
 
-    it("parseArgs should have a side effect of altering parameters", async () => {
+    it("parseArgs should not have a side effect of altering parameters", async () => {
         const rawArgs = ["4"];
         const argumentsInfo: Argument[] = [
             {
@@ -335,7 +335,7 @@ describe("Testing base.ts/parseArgs()", () => {
         );
     });
 
-    it("should parse an array of values when infinite is true", async () => {
+    it("parseArgs should parse an array of values when infinite is true", async () => {
         const rawArgs = ["4"];
         const argumentsInfo: Argument[] = [
             {
@@ -354,7 +354,7 @@ describe("Testing base.ts/parseArgs()", () => {
         expect(result).toEqual(expected);
     });
 
-    it("should error if the infinite flag is true for any argument that isn't the last", async () => {
+    it("parseArgs should error if the infinite flag is true for any argument that isn't the last", async () => {
         const rawArgs = ["1", "2", "string"];
         const argumentsInfo: Argument[] = [
             {

--- a/tests/custom/validators.test.ts
+++ b/tests/custom/validators.test.ts
@@ -3,7 +3,7 @@ import {
     validateBoolean,
     validateNumber,
     validateUser,
-} from "../../v12_src/custom/validators";
+} from "../../src/custom/validators";
 
 describe("validateNumber", () => {
     it("validateNumber should parse and return the number if a number is passed", () => {


### PR DESCRIPTION
This PR just cleans up the `base.ts` file with its docstrings and refactoring for some cleaner code. The behavior has not changed. In addition, the unit tests for this file has been fixed up and a limited run of them has been added back into the GitHub actions.

Changes:
- `test` script adds `base.test.ts` and `validators.test.ts`
- docstrings updated
- infinite parameter parsing for final value has been refactored
- type declarations have been moved
- new test cases for infinite parameter
- test cases mock the `validateUser()` function