### PR TITLE
Feature: Queue YouTube Playlists

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "lint": "eslint .",
         "prestart": "npm i ytdl-core@latest ytsr@latest",
         "start": "node dist/index.js",
-        "test": "npm run clean-build && npm run clean-test && jest tests/custom/ytclient.test.ts tests/custom/validators.test.ts tests/custom/base.test.ts --silent --verbose"
+        "test": "npm run clean-build && npm run clean-test && jest tests/custom/ytclient.test.ts tests/custom/validators.test.ts tests/custom/base.test.ts tests/commands/music/queue.test.ts --silent --verbose"
     },
     "lint-staged": {
         "{src,tests}/**/*": [

--- a/src/commands/music/queue.ts
+++ b/src/commands/music/queue.ts
@@ -124,7 +124,6 @@ const queueCommand: Command = {
             return null;
         }
         for (const i in tracks) {
-            console.log(parseInt(i));
             mm.queue(tracks[i], queuePosition + parseInt(i));
         }
         log.debug(f("queue", `Queued track(s): ${JSON.stringify(tracks)}`));

--- a/src/commands/music/queue.ts
+++ b/src/commands/music/queue.ts
@@ -65,6 +65,28 @@ const queueCommand: Command = {
         const yt = new YTClient();
         let track: Track | null = null;
 
+        // If the user wants a playlist, try to get a playlist
+        const playlistFlag = "--playlist";
+        if (trackString.includes(playlistFlag)) {
+            const playlistLink = trackString.replace(playlistFlag, "").trim();
+            try {
+                const ytPlaylist = await yt.getPlaylist(playlistLink);
+                for (const ytplTrack of ytPlaylist) {
+                    mm.queue(ytplTrack, mm.queueLength());
+                }
+                message.channel.send(
+                    mm.playlist.slice(0, 5).map((t, index) => {
+                        return `${index + 1}. ${t.title}`;
+                    })
+                );
+            } catch (error) {
+                log.debug(
+                    f("queue", `Unable to retrieve playlist: ${(error as Error).message}`)
+                );
+            }
+            return null;
+        }
+
         // Try to get the video directly
         if (!track) {
             log.debug(f("queue", `Trying to get a direct video from '${trackString}'`));

--- a/tests/commands/music/queue.test.ts
+++ b/tests/commands/music/queue.test.ts
@@ -89,7 +89,7 @@ describe("Queue command tests", () => {
         expect(mm.playlist[1]).toEqual(track);
     });
 
-    it("queuCommand should add a track to the queue from a direct YouTube video link", async () => {
+    it("queueCommand should add a track to the queue from a direct YouTube video link", async () => {
         message.content = process.env.PREFIX! + "queue youtube.link";
         const args: ArgumentValues = await parseArgs(
             message.content.split(/[ ]+/).slice(1),
@@ -144,11 +144,11 @@ describe("Queue command tests", () => {
             {} as any
         );
 
-        const messageSpy = jest.spyOn(message, "reply");
+        const getQueuePreviewSpy = jest.spyOn(mm, "getQueuePreview");
 
         await queueCommand.run(message, args);
 
-        expect(messageSpy.mock.calls[0][0][0].includes("Currently Queued")).toBe(true);
+        expect(getQueuePreviewSpy).toHaveBeenCalledTimes(1);
         expect(mm.queueLength()).toBeGreaterThan(0);
     });
 
@@ -252,14 +252,14 @@ describe("Queue command tests", () => {
             {} as any
         );
 
-        const messageSpy = jest.spyOn(message, "reply");
+        const getQueuePreviewSpy = jest.spyOn(mm, "getQueuePreview");
         mmQueueSpy.mockClear();
 
         expect(mm.queueLength()).toBe(1);
 
         await queueCommand.run(message, args);
 
-        expect(messageSpy).not.toHaveBeenCalled();
+        expect(getQueuePreviewSpy).not.toHaveBeenCalled();
         expect(mmQueueSpy).toHaveBeenCalledTimes(1);
         expect(mm.queueLength()).toBe(2);
         expect(mm.playlist[0]).toEqual(track);

--- a/tests/commands/music/queue.test.ts
+++ b/tests/commands/music/queue.test.ts
@@ -1,0 +1,267 @@
+import MusicManager, { Track } from "../../../src/custom/music-manager";
+import queueCommand from "../../../src/commands/music/queue";
+import { ArgumentValues, parseArgs } from "../../../src/custom/base";
+import "dotenv/config";
+import { YTClient } from "../../../src/custom/ytclient";
+
+describe("Queue command tests", () => {
+    /**
+     * All tests will be setup with the following conditions
+     *
+     * - YTClient calls are all mocked to return a specific Track object
+     * - The default behavior of YTClient calls will be defaulting to search calls
+     * - MusicManager voice related functions are mocked with an empty function
+     * - A 'track' object has been defined for all test that are expected to queue (used in mocks)
+     *
+     */
+
+    let mm: MusicManager;
+    let message: any;
+    let mmQueueSpy: jest.SpyInstance;
+    let ytClientSearchSpy: jest.SpyInstance;
+    let ytClientGetPlaylistSpy: jest.SpyInstance;
+    let ytClientGetVideoSpy: jest.SpyInstance;
+    let track: Track;
+
+    beforeAll(() => {
+        const client: any = {
+            on: jest.fn(),
+        };
+        mm = MusicManager.getInstance(client);
+    });
+
+    beforeEach(() => {
+        jest.restoreAllMocks();
+
+        message = {
+            content: process.env.PREFIX! + "queue asdfa",
+            reply: jest.fn(),
+        };
+
+        jest.spyOn(MusicManager, "getInstance").mockImplementation(() => mm);
+        jest.spyOn(mm, "connect").mockImplementation(jest.fn());
+        jest.spyOn(mm, "disconnect").mockImplementation(jest.fn());
+        jest.spyOn(mm, "play").mockImplementation(jest.fn());
+        mmQueueSpy = jest.spyOn(mm, "queue");
+        mm.clearQueue();
+
+        track = {
+            title: "Test title",
+            link: "youtube.link",
+            duration: "2:30",
+        };
+        ytClientSearchSpy = jest
+            .spyOn(YTClient.prototype, "search")
+            .mockImplementation(async () => track);
+        ytClientGetPlaylistSpy = jest
+            .spyOn(YTClient.prototype, "getPlaylist")
+            .mockImplementation(async () => {
+                throw new Error();
+            });
+        ytClientGetVideoSpy = jest
+            .spyOn(YTClient.prototype, "getVideo")
+            .mockImplementation(async () => {
+                throw new Error();
+            });
+    });
+
+    it("queueCommand should add a track to the end of the queue from a YouTube search", async () => {
+        mm.queue({
+            title: "Previous title",
+            link: "previous.link",
+            duration: "4:20",
+        });
+        mmQueueSpy.mockClear();
+
+        message.content = process.env.PREFIX! + "queue Test title";
+        const args: ArgumentValues = await parseArgs(
+            message.content.split(/[ ]+/).slice(1),
+            queueCommand.arguments,
+            {} as any
+        );
+
+        expect(mm.queueLength()).toBe(1);
+
+        await queueCommand.run(message, args);
+
+        expect(mmQueueSpy).toHaveBeenCalledTimes(1);
+        expect(mm.queueLength()).toBe(2);
+        expect(mm.playlist[1]).toEqual(track);
+    });
+
+    it("queuCommand should add a track to the queue from a direct YouTube video link", async () => {
+        message.content = process.env.PREFIX! + "queue youtube.link";
+        const args: ArgumentValues = await parseArgs(
+            message.content.split(/[ ]+/).slice(1),
+            queueCommand.arguments,
+            {} as any
+        );
+
+        ytClientGetVideoSpy = jest
+            .spyOn(YTClient.prototype, "getVideo")
+            .mockImplementation(async () => track);
+
+        expect(mm.queueLength()).toBe(0);
+
+        await queueCommand.run(message, args);
+
+        expect(ytClientGetVideoSpy).toHaveBeenCalledTimes(1);
+        expect(ytClientSearchSpy).not.toHaveBeenCalled();
+        expect(mmQueueSpy).toHaveBeenCalledTimes(1);
+        expect(mm.queueLength()).toBe(1);
+    });
+
+    it("queueCommand should add multiple tracks to the queue from a YouTube playlist", async () => {
+        message.content = process.env.PREFIX! + "queue Test title --playlist";
+        const args: ArgumentValues = await parseArgs(
+            message.content.split(/[ ]+/).slice(1),
+            queueCommand.arguments,
+            {} as any
+        );
+
+        ytClientGetPlaylistSpy = jest
+            .spyOn(YTClient.prototype, "getPlaylist")
+            .mockImplementation(async () => [track, track, track]);
+
+        expect(mm.queueLength()).toBe(0);
+
+        await queueCommand.run(message, args);
+
+        expect(ytClientGetPlaylistSpy).toHaveBeenCalledTimes(1);
+        expect(ytClientGetVideoSpy).not.toHaveBeenCalled();
+        expect(ytClientSearchSpy).not.toHaveBeenCalled();
+        expect(mmQueueSpy).toHaveBeenCalledTimes(3);
+        expect(mm.queueLength()).toBe(3);
+    });
+
+    it("queueCommand should attempt to display the queue if there are tracks in the queue", async () => {
+        mm.queue(track);
+
+        message.content = process.env.PREFIX! + "queue";
+        const args: ArgumentValues = await parseArgs(
+            message.content.split(/[ ]+/).slice(1),
+            queueCommand.arguments,
+            {} as any
+        );
+
+        const messageSpy = jest.spyOn(message, "reply");
+
+        await queueCommand.run(message, args);
+
+        expect(messageSpy.mock.calls[0][0][0].includes("Currently Queued")).toBe(true);
+        expect(mm.queueLength()).toBeGreaterThan(0);
+    });
+
+    it("queueCommand should send a message saying there are no tracks in queue to display", async () => {
+        message.content = process.env.PREFIX! + "queue";
+        const args: ArgumentValues = await parseArgs(
+            message.content.split(/[ ]+/).slice(1),
+            queueCommand.arguments,
+            {} as any
+        );
+
+        const messageSpy = jest.spyOn(message, "reply");
+
+        await queueCommand.run(message, args);
+
+        expect(messageSpy.mock.calls[0][0]).toEqual("No tracks left in queue.");
+        expect(mm.queueLength()).toBe(0);
+    });
+
+    it("queueCommand should clear the queue", async () => {
+        mm.queue(track);
+
+        message.content = process.env.PREFIX! + "queue clear";
+        const args: ArgumentValues = await parseArgs(
+            message.content.split(/[ ]+/).slice(1),
+            queueCommand.arguments,
+            {} as any
+        );
+
+        const clearQueueSpy = jest.spyOn(mm, "clearQueue");
+
+        expect(mm.queueLength()).toBe(1);
+
+        await queueCommand.run(message, args);
+
+        expect(mm.queueLength()).toBe(0);
+        expect(clearQueueSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("queueCommand should send an error message if the YTClient doesn't return any valid results", async () => {
+        message.content = process.env.PREFIX! + "queue bad search title";
+        const args: ArgumentValues = await parseArgs(
+            message.content.split(/[ ]+/).slice(1),
+            queueCommand.arguments,
+            {} as any
+        );
+
+        ytClientGetVideoSpy = jest
+            .spyOn(YTClient.prototype, "getVideo")
+            .mockImplementation(async () => {
+                throw new Error();
+            });
+        ytClientSearchSpy = jest
+            .spyOn(YTClient.prototype, "search")
+            .mockImplementation(async () => {
+                throw new Error();
+            });
+
+        await queueCommand.run(message, args);
+
+        expect(ytClientGetVideoSpy).toHaveBeenCalledTimes(1);
+        expect(ytClientSearchSpy).toHaveBeenCalledTimes(1);
+        expect(mmQueueSpy).not.toHaveBeenCalled();
+        expect(mm.queueLength()).toBe(0);
+    });
+
+    it("queueCommand should send an error message if the YTClient doesn't return any valid playlist results", async () => {
+        message.content = process.env.PREFIX! + "queue bad playlist --playlist";
+        const args: ArgumentValues = await parseArgs(
+            message.content.split(/[ ]+/).slice(1),
+            queueCommand.arguments,
+            {} as any
+        );
+
+        ytClientGetPlaylistSpy = jest
+            .spyOn(YTClient.prototype, "getPlaylist")
+            .mockImplementation(async () => {
+                throw new Error();
+            });
+
+        await queueCommand.run(message, args);
+
+        expect(ytClientGetPlaylistSpy).toHaveBeenCalledTimes(1);
+        expect(ytClientGetVideoSpy).not.toHaveBeenCalled();
+        expect(ytClientSearchSpy).not.toHaveBeenCalled();
+        expect(mmQueueSpy).not.toHaveBeenCalled();
+        expect(mm.queueLength()).toBe(0);
+    });
+
+    it("queueCommand should not display a message and it should queue at the beginning if called from the use of another command", async () => {
+        mm.queue({
+            title: "Previous title",
+            link: "previous.link",
+            duration: "4:20",
+        });
+
+        message.content = process.env.PREFIX! + "play Test title";
+        const args: ArgumentValues = await parseArgs(
+            message.content.split(/[ ]+/).slice(1),
+            queueCommand.arguments,
+            {} as any
+        );
+
+        const messageSpy = jest.spyOn(message, "reply");
+        mmQueueSpy.mockClear();
+
+        expect(mm.queueLength()).toBe(1);
+
+        await queueCommand.run(message, args);
+
+        expect(messageSpy).not.toHaveBeenCalled();
+        expect(mmQueueSpy).toHaveBeenCalledTimes(1);
+        expect(mm.queueLength()).toBe(2);
+        expect(mm.playlist[0]).toEqual(track);
+    });
+});


### PR DESCRIPTION
In this PR, the functionality for queueing up YouTube playlists have been introduced. The queue command expects a direct YouTube link to the playlist along with a `--playlist` flag and it will try to parse each video as a track and add it to the queue. This functionality will also work with the play command, but instead of adding the playlist to the end of the queue, the play command will queue it to the front and begin playing it immediately.

The queue's display has been changed to a preview of the first few songs. If there are many more songs than what the preview can display, then it will contain an ellipses and show the final song in the queue.

Changes:
- `queue` command updated with an additional check for the playlist inputs
- `queue` command changed variable from track to tracks, where it assigns an array of tracks to be queued
- `queue.test.ts` tests have been created
- `MusicManager` now has the functionality for displaying a preview of the queue.